### PR TITLE
Home view diffable data source type Int instead of Movie.

### DIFF
--- a/NetflixClone/Classes/Scenes/Home/HomeViewModel.swift
+++ b/NetflixClone/Classes/Scenes/Home/HomeViewModel.swift
@@ -12,14 +12,14 @@ class HomeViewModel {
     
     // MARK: - Properties
     private let remote = DiscoverMoviesRemote()
+    private let movieStore = MovieStore()
     private var hasMoreMovies = true
-    
     var cancellables: Set<AnyCancellable> = []
-        
-    @Published private(set) var result = NewMovies(newMovies: [], section: .featured)
+    
+    @Published private(set) var fetchedMovieIds = NewMovies(newMoviesIds: [], section: .featured)
     
     struct NewMovies {
-        var newMovies: [Movie]
+        var newMoviesIds: [Int]
         var section: Section
     }
 
@@ -48,11 +48,16 @@ class HomeViewModel {
                 }
                 self.hasMoreMovies = movies.count > 0
                 guard hasMoreMovies else { return }
-                result = NewMovies(newMovies: movies, section: section)
+                
+                movieStore.addMovies(movies: movies)
+                fetchedMovieIds = NewMovies(newMoviesIds: movies.map{$0.id}, section: section)
             } catch {
                 print("❌ Error: \(error)")
             }
         }
+    }
+    func fetchMovieById(id: Int) -> Movie? {
+        return movieStore.fetchMovieById(id: id)
     }
     
 }


### PR DESCRIPTION
As per WWDC session [Make blazing fast lists and collection views](https://developer.apple.com/videos/play/wwdc2021/10252/ )
and sample project [Building High-Performance Lists and Collection Views](https://developer.apple.com/documentation/uikit/uiimage/building_high-performance_lists_and_collection_views)

Diffable Data Source should store an id for an object instead of the object itself (for better performance with large collection views).